### PR TITLE
Fix build: add Templates to sparse checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           repository: opnsense/plugins
           path: opnsense-plugins
-          sparse-checkout: Mk
+          sparse-checkout: |
+            Mk
+            Templates
           sparse-checkout-cone-mode: false
 
       - name: Setup plugin in tree


### PR DESCRIPTION
The OPNsense plugins Mk infrastructure requires Templates/actions.d for package building. The sparse checkout was only fetching Mk/.