### PR TITLE
Remove -devel suffix from package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,6 @@ PLUGIN_REVISION=	0
 PLUGIN_DEPENDS=		dnsmasq
 PLUGIN_COMMENT=		Register dnsmasq DHCP leases and static hosts in Unbound DNS
 PLUGIN_MAINTAINER=	chall37@users.noreply.github.com
+PLUGIN_DEVEL=
 
 .include "../../Mk/plugins.mk"


### PR DESCRIPTION
Set PLUGIN_DEVEL= (empty) to produce os-dnsmasq-to-unbound instead of os-dnsmasq-to-unbound-devel